### PR TITLE
🩹 fixes the default github URL to edit the docs page

### DIFF
--- a/docs/data.ts
+++ b/docs/data.ts
@@ -28,8 +28,7 @@ export const PACKAGE_DATA: PackageData = {
   packageName: 'mantine-extension-template',
   packageDescription:
     'A template for mantine extensions, includes full setup for package development and documentation',
-  mdxFileUrl:
-    'https://github.com/rtivital/mantine-extension-template/blob/master/docs/pages/index.mdx',
+  mdxFileUrl: 'https://github.com/rtivital/mantine-extension-template/blob/master/docs/docs.mdx',
   repositoryUrl: 'https://github.com/rtivital/mantine-extension-template',
   licenseUrl: 'https://github.com/rtivital/mantine-extension-template/blob/master/LICENSE',
   author: {


### PR DESCRIPTION
- Just to avoid "404" by clicking the "Edit Docs" in the header