### PR TITLE
✨ fixes the props componentPrefix

### DIFF
--- a/docs/components/DocsTabs/DocsTabs.tsx
+++ b/docs/components/DocsTabs/DocsTabs.tsx
@@ -93,7 +93,11 @@ export function DocsTabs({
 
         <Tabs.Panel value="props">
           <div className={classes.tabContent} data-secondary>
-            <PropsTablesList components={componentsProps!} data={docgen} />
+            <PropsTablesList
+              components={componentsProps!}
+              componentPrefix={componentPrefix}
+              data={docgen}
+            />
           </div>
         </Tabs.Panel>
 

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { DocsTabs } from '../components/DocsTabs';
 import { PageHeader } from '../components/PageHeader';
 import { Shell } from '../components/Shell';
@@ -15,6 +14,7 @@ export default function HomePage() {
         docgen={docgen}
         componentsProps={['TestComponent']}
         componentsStyles={['TestComponent']}
+        componentPrefix="TestComponent"
         stylesApiData={STYLES_API_DATA}
       >
         <Docs />


### PR DESCRIPTION
- Fix the lack of `componentPrefix` so that the exported components are displayed correctly in the Props section, for example, instead of

```
TestComponentTarget
```

```
TestComponent.Target
```